### PR TITLE
Fix fork_point example

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -434,7 +434,7 @@ revsets (expressions) as arguments.
     * `fork_point(E|B)` ⇒ `{B}`
     * `fork_point(E|A)` ⇒ `{A}`
     * `fork_point(D|C)` ⇒ `{C}`
-    * `fork_point(D|B)` ⇒ `{A}`
+    * `fork_point(D|B)` ⇒ `{B}`
     * `fork_point(B|C)` ⇒ `{A}`
     * `fork_point(A)` ⇒ `{A}`
     * `fork_point(none())` ⇒ `{}`


### PR DESCRIPTION
As discussed on Discord the example for fork_point seems incorrect:

```
o E
|
| o D
|/|
| o C
| |
o | B
|/
o A
|
o root()


* `fork_point(E|D)` ⇒ `{B}`
* `fork_point(E|B)` ⇒ `{B}`
* `fork_point(D|B)` ⇒ `{A}`
```
The last one should also be `{B}`